### PR TITLE
fix: update the URL references to the project itself with the new name

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: 💬 Discussions
-    url: https://github.com/avalin/unity-ci-templates/discussions
+    url: https://github.com/avalin/unity-ci-cd/discussions
     about: Ask general questions or share ideas in Discussions.

--- a/.github/actions/analyze-artifact-strategy/analyze-artifact-strategy.sh
+++ b/.github/actions/analyze-artifact-strategy/analyze-artifact-strategy.sh
@@ -4,7 +4,7 @@ set -e
 DEPLOY_TARGETS="$1"
 ARTIFACT_SOURCE="$2"
 CONFIG_FILE=".github/config/deploy-targets.json"
-FALLBACK_URL="https://raw.githubusercontent.com/avalin/unity-ci-templates/main/.github/config/deploy-targets.json"
+FALLBACK_URL="https://raw.githubusercontent.com/avalin/unity-ci-cd/main/.github/config/deploy-targets.json"
 
 # ────────────────────────────────────────────────
 echo "🔍 Loading deploy-targets.json..."

--- a/.github/actions/prepare-metadata/action.yml
+++ b/.github/actions/prepare-metadata/action.yml
@@ -110,21 +110,21 @@ runs:
   steps:
     - name: 📦 Resolve Project Name
       id: project_name
-      uses: avalin/unity-ci-templates/.github/actions/resolve-project-name@main
+      uses: avalin/unity-ci-cd/.github/actions/resolve-project-name@main
       with:
         projectNameInput: ${{ inputs.projectNameInput }}
         projectNameRepoVar: ${{ inputs.projectNameRepoVar }}
 
     - name: 📦 Resolve Unity Version
       id: unity_version
-      uses: avalin/unity-ci-templates/.github/actions/resolve-unity-version@main
+      uses: avalin/unity-ci-cd/.github/actions/resolve-unity-version@main
       with:
         unityVersionInput: ${{ inputs.unityVersionInput }}
         unityVersionRepoVar: ${{ inputs.unityVersionRepoVar }}
 
     - name: ⚙️ Resolve CI Options
       id: ci_options
-      uses: avalin/unity-ci-templates/.github/actions/resolve-ci-config@main
+      uses: avalin/unity-ci-cd/.github/actions/resolve-ci-config@main
       with:
         useGitLfsInput: ${{ inputs.useGitLfsInput }}
         useGitLfsRepoVar: ${{ inputs.useGitLfsRepoVar }}
@@ -137,7 +137,7 @@ runs:
 
     - name: 📦 Resolve Test Config
       id: test_config
-      uses: avalin/unity-ci-templates/.github/actions/resolve-test-config@main
+      uses: avalin/unity-ci-cd/.github/actions/resolve-test-config@main
       with:
         editModePathInput: ${{ inputs.editModePathInput }}
         editModePathRepoVar: ${{ inputs.editModePathRepoVar }}
@@ -146,13 +146,13 @@ runs:
 
     - name: 📦 Resolve Build Type
       id: build_type
-      uses: avalin/unity-ci-templates/.github/actions/resolve-build-type@main
+      uses: avalin/unity-ci-cd/.github/actions/resolve-build-type@main
       with:
         buildTypeOverride: ${{ inputs.buildTypeInput }}
 
     - name: 📦 Resolve Timeouts
       id: timeouts
-      uses: avalin/unity-ci-templates/.github/actions/resolve-timeouts@main
+      uses: avalin/unity-ci-cd/.github/actions/resolve-timeouts@main
       with:
         timeoutTestsInput: ${{ inputs.timeoutTestsInput }}
         timeoutTestsRepoVar: ${{ inputs.timeoutTestsRepoVar }}
@@ -161,7 +161,7 @@ runs:
 
     - name: 📦 Resolve Retention Days
       id: retention
-      uses: avalin/unity-ci-templates/.github/actions/resolve-retention-days@main
+      uses: avalin/unity-ci-cd/.github/actions/resolve-retention-days@main
       with:
         buildType: ${{ steps.build_type.outputs.buildType }}
         retentionDaysReleaseRepoVar: ${{ inputs.retentionDaysReleaseRepoVar }}
@@ -170,7 +170,7 @@ runs:
 
     - name: 📦 Resolve Build Targets
       id: build_targets
-      uses: avalin/unity-ci-templates/.github/actions/resolve-build-targets@main
+      uses: avalin/unity-ci-cd/.github/actions/resolve-build-targets@main
       with:
         buildType: ${{ steps.build_type.outputs.buildType }}
         buildTargetsInput: ${{ inputs.buildTargetsInput }}
@@ -178,7 +178,7 @@ runs:
 
     - name: 📦 Resolve Deploy Targets
       id: deploy_targets
-      uses: avalin/unity-ci-templates/.github/actions/validate-deploy-targets@main
+      uses: avalin/unity-ci-cd/.github/actions/validate-deploy-targets@main
       with:
         buildType: ${{ steps.build_type.outputs.buildType }}
         buildTargets: ${{ steps.build_targets.outputs.buildTargets }}
@@ -186,7 +186,7 @@ runs:
 
     - name: 📦 Analyze Artifact Strategy
       id: artifact_strategy
-      uses: avalin/unity-ci-templates/.github/actions/analyze-artifact-strategy@main
+      uses: avalin/unity-ci-cd/.github/actions/analyze-artifact-strategy@main
       with:
         deployTargets: ${{ steps.deploy_targets.outputs.deployTargets }}
         artifactSource: ${{ inputs.artifactSource }}

--- a/.github/actions/validate-deploy-targets/validate-deploy-targets.sh
+++ b/.github/actions/validate-deploy-targets/validate-deploy-targets.sh
@@ -5,7 +5,7 @@ RAW_INPUT="$1"
 BUILD_TYPE="$2"
 BUILD_TARGETS_RAW="$3"
 CONFIG_FILE=".github/config/deploy-targets.json"
-FALLBACK_URL="https://raw.githubusercontent.com/avalin/unity-ci-templates/main/.github/config/deploy-targets.json"
+FALLBACK_URL="https://raw.githubusercontent.com/avalin/unity-ci-cd/main/.github/config/deploy-targets.json"
 
 # ─────────────────────────────────────────────────────────────
 # Step 1: Validate JSON input

--- a/.github/workflows/build-version-resolver.yml
+++ b/.github/workflows/build-version-resolver.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Resolve Build Version
         id: get_version
-        uses: avalin/unity-ci-templates/.github/actions/resolve-build-version@main
+        uses: avalin/unity-ci-cd/.github/actions/resolve-build-version@main
         with:
           ref: "${GITHUB_REF}"
           event: "${GITHUB_EVENT_NAME}"
@@ -49,7 +49,7 @@ jobs:
 
       - name: 📝 Check if Release Version Already Exists
         id: check_release
-        uses: avalin/unity-ci-templates/.github/actions/check-release-exists@main
+        uses: avalin/unity-ci-cd/.github/actions/check-release-exists@main
         with:
           version: ${{ steps.get_version.outputs.version }}
           repo: ${{ github.repository }}

--- a/.github/workflows/build-version-tagger.yml
+++ b/.github/workflows/build-version-tagger.yml
@@ -42,7 +42,7 @@ jobs:
     steps:
       - name: Check if Tag Exists
         id: tag_exists
-        uses: avalin/unity-ci-templates/.github/actions/check-tag-exists@v1
+        uses: avalin/unity-ci-cd/.github/actions/check-tag-exists@v1
         with:
           version: ${{ inputs.buildVersion }}
           repository: ${{ github.repository }}
@@ -50,7 +50,7 @@ jobs:
 
       - name: Create Tag if Missing
         if: ${{ steps.tag_exists.outputs.exists != 'true' }}
-        uses: avalin/unity-ci-templates/.github/actions/create-tag@v1
+        uses: avalin/unity-ci-cd/.github/actions/create-tag@v1
         id: create
         with:
           sha: ${{ github.sha }}

--- a/.github/workflows/ci-cd-dispatcher.yml
+++ b/.github/workflows/ci-cd-dispatcher.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Resolve runners
         id: resolve
-        uses: avalin/unity-ci-templates/.github/actions/resolve-runners@main
+        uses: avalin/unity-ci-cd/.github/actions/resolve-runners@main
         with:
           main: ${{ vars.MAIN_RUNNER }}
           macos: ${{ vars.MACOS_RUNNER }}

--- a/.github/workflows/ci-cd-redeployer.yml
+++ b/.github/workflows/ci-cd-redeployer.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
       - name: Run Project Name Sanitizer
         id: sanitize
-        uses: avalin/unity-ci-templates/.github/actions/resolve-project-name@main
+        uses: avalin/unity-ci-cd/.github/actions/resolve-project-name@main
         with:
           projectNameInput: ${{ vars.PROJECT_NAME }}
 

--- a/.github/workflows/group-build-targets-by-os.yml
+++ b/.github/workflows/group-build-targets-by-os.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           INPUT_JSON='${{ inputs.buildTargets }}'
           CONFIG_FILE=".github/config/build-targets.json"
-          FALLBACK_URL="https://raw.githubusercontent.com/avalin/unity-ci-templates/main/.github/config/build-targets.json"
+          FALLBACK_URL="https://raw.githubusercontent.com/avalin/unity-ci-cd/main/.github/config/build-targets.json"
 
           echo "🔍 Validating input build targets: $INPUT_JSON"
 

--- a/.github/workflows/prepare-metadata.yml
+++ b/.github/workflows/prepare-metadata.yml
@@ -109,7 +109,7 @@ jobs:
 
       - name: ⏳ Prepare Metadata
         id: metadata
-        uses: avalin/unity-ci-templates/.github/actions/prepare-metadata@main
+        uses: avalin/unity-ci-cd/.github/actions/prepare-metadata@main
         with:
           artifactSource: build
           projectNameInput: ${{ inputs.projectName }}
@@ -157,13 +157,13 @@ jobs:
 
       - name: 🔍 Detect Tests-Only Mode
         id: tests_only
-        uses: avalin/unity-ci-templates/.github/actions/detect-tests-only@main
+        uses: avalin/unity-ci-cd/.github/actions/detect-tests-only@main
         with:
           testsOnlyInput: ${{ inputs.testsOnly }}
 
       - name: 🔍 Detect Skip Tests Flag
         id: skip_tests
-        uses: avalin/unity-ci-templates/.github/actions/detect-skip-tests@main
+        uses: avalin/unity-ci-cd/.github/actions/detect-skip-tests@main
         with:
           skipTestsInput: ${{ inputs.skipTests }}
           skipTestsRepoVar: ${{ steps.metadata.outputs.excludeUnityTests }}

--- a/.github/workflows/resolve-deploy-matrix.yml
+++ b/.github/workflows/resolve-deploy-matrix.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           DEPLOY_TARGETS='${{ inputs.validTargets }}'
           CONFIG_FILE=".github/config/deploy-targets.json"
-          FALLBACK_URL="https://raw.githubusercontent.com/avalin/unity-ci-templates/main/.github/config/deploy-targets.json"
+          FALLBACK_URL="https://raw.githubusercontent.com/avalin/unity-ci-cd/main/.github/config/deploy-targets.json"
 
           echo "🔍 Checking for local config file..."
           if [ -f "$CONFIG_FILE" ]; then

--- a/.github/workflows/step-1-test.yml
+++ b/.github/workflows/step-1-test.yml
@@ -71,7 +71,7 @@ jobs:
       has_playmode: ${{ steps.detect.outputs.has_playmode }}
     steps:
       - id: detect
-        uses: avalin/unity-ci-templates/.github/actions/detect-tests-existence@main
+        uses: avalin/unity-ci-cd/.github/actions/detect-tests-existence@main
         with:
           editModePath: ${{ inputs.editModePath }}
           playModePath: ${{ inputs.playModePath }}

--- a/.github/workflows/step-2-build.yml
+++ b/.github/workflows/step-2-build.yml
@@ -111,7 +111,7 @@ jobs:
 
       - name: Resolve Build Profile
         id: resolve_build_profile
-        uses: avalin/unity-ci-templates/.github/actions/resolve-build-profile@main
+        uses: avalin/unity-ci-cd/.github/actions/resolve-build-profile@main
         with:
           buildTarget: ${{ matrix.buildTarget }}
           buildType: ${{ inputs.buildType }}
@@ -119,7 +119,7 @@ jobs:
 
       - name: Resolve Unity Run Parameters
         id: resolve_run_parameters
-        uses: avalin/unity-ci-templates/.github/actions/resolve-unity-run-parameters@main
+        uses: avalin/unity-ci-cd/.github/actions/resolve-unity-run-parameters@main
         with:
           buildTarget: ${{ matrix.buildTarget }}
 

--- a/.github/workflows/step-3-release.yml
+++ b/.github/workflows/step-3-release.yml
@@ -59,13 +59,13 @@ jobs:
 
       - name: 📝 Create GitHub Release
         id: create_release
-        uses: avalin/unity-ci-templates/.github/actions/create-release@main
+        uses: avalin/unity-ci-cd/.github/actions/create-release@main
         with:
           version: ${{ inputs.buildVersion }}
           githubToken: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 🧮 Upload Per-Platform Artifacts
-        uses: avalin/unity-ci-templates/.github/actions/upload-per-build-target-artifacts@main
+        uses: avalin/unity-ci-cd/.github/actions/upload-per-build-target-artifacts@main
         with:
           project: ${{ inputs.projectName }}
           version: ${{ inputs.buildVersion }}

--- a/.github/workflows/step-4-deploy.yml
+++ b/.github/workflows/step-4-deploy.yml
@@ -86,7 +86,7 @@ jobs:
       ARTIFACT_DIR: deployment-artifacts/${{ inputs.projectName }}-${{ inputs.buildVersion }}
     steps:
       - name: 📥 Retrieve Artifacts from Release
-        uses: avalin/unity-ci-templates/.github/actions/download-from-release@main
+        uses: avalin/unity-ci-cd/.github/actions/download-from-release@main
         with:
           projectName: ${{ inputs.projectName }}
           version: ${{ inputs.buildVersion }}
@@ -105,7 +105,7 @@ jobs:
 
       - name: 📥 Retrieve Artifacts from Build (Per-Build-Target)
         if: ${{ inputs.artifactSource == 'build' && inputs.hasCombinedArtifacts == 'false' }}
-        uses: avalin/unity-ci-templates/.github/actions/download-per-build-target-artifacts-from-build@main
+        uses: avalin/unity-ci-cd/.github/actions/download-per-build-target-artifacts-from-build@main
         with:
           artifactDir: ${{ env.ARTIFACT_DIR }}
           projectName: ${{ inputs.projectName }}
@@ -116,7 +116,7 @@ jobs:
 
       - name: 🛠️ Normalize Artifact Layout (Release Per-Build-Target Only)
         if: ${{ inputs.artifactSource == 'release' && inputs.hasCombinedArtifacts == 'false' }}
-        uses: avalin/unity-ci-templates/.github/actions/normalize-artifact-layout@main
+        uses: avalin/unity-ci-cd/.github/actions/normalize-artifact-layout@main
         with:
           artifactDir: ${{ env.ARTIFACT_DIR }}
 
@@ -134,13 +134,13 @@ jobs:
 
       - name: 🔎 Detect WebGL Compression Format
         id: detect-compression
-        uses: avalin/unity-ci-templates/.github/actions/detect-webgl-compression@main
+        uses: avalin/unity-ci-cd/.github/actions/detect-webgl-compression@main
         with:
           artifactDir: ${{ env.ARTIFACT_DIR }}
 
       - name: 🩹 Patch & Decompress Unity WebGL for GitHub Pages
         if: ${{ matrix.target == 'gh-pages' && steps.detect-compression.outputs.needs_patch == 'true' }}
-        uses: avalin/unity-ci-templates/.github/actions/patch-webgl-for-gh-pages@main
+        uses: avalin/unity-ci-cd/.github/actions/patch-webgl-for-gh-pages@main
         with:
           artifactDir: ${{ env.ARTIFACT_DIR }}
 

--- a/.github/workflows/step-5-notify.yml
+++ b/.github/workflows/step-5-notify.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Generate Notification
         id: generate_notification
-        uses: avalin/unity-ci-templates/.github/actions/generate-notification@v1
+        uses: avalin/unity-ci-cd/.github/actions/generate-notification@v1
         with:
           releaseResult: ${{ inputs.releaseResult }}
           releaseErrorMessage: ${{ inputs.releaseErrorMessage }}

--- a/CICD_Workflows/ci-cd-dispatcher.yml
+++ b/CICD_Workflows/ci-cd-dispatcher.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Resolve runners
         id: resolve
-        uses: avalin/unity-ci-templates/.github/actions/resolve-runners@main
+        uses: avalin/unity-ci-cd/.github/actions/resolve-runners@main
         with:
           main: ${{ vars.MAIN_RUNNER }}
           macos: ${{ vars.MACOS_RUNNER }}
@@ -130,7 +130,7 @@ jobs:
       - resolve_runners
       - validation
     if: ${{ needs.validation.outputs.should_run == 'true'}}
-    uses: avalin/unity-ci-templates/.github/workflows/prepare-metadata.yml@main
+    uses: avalin/unity-ci-cd/.github/workflows/prepare-metadata.yml@main
     with:
       runnerMain: ${{ needs.resolve_runners.outputs.main }}
       unityVersion: ${{ vars.UNITY_VERSION }}
@@ -148,7 +148,7 @@ jobs:
       - resolve_runners
       - prepare_metadata
     if: ${{ needs.validation.outputs.should_run == 'true'}}
-    uses: avalin/unity-ci-templates/.github/workflows/build-version-tagger.yml@main
+    uses: avalin/unity-ci-cd/.github/workflows/build-version-tagger.yml@main
     with:
       runnerMain: ${{ needs.resolve_runners.outputs.main }}
       buildType: ${{ needs.prepare_metadata.outputs.buildType }}

--- a/CICD_Workflows/ci-cd-pipeline.yml
+++ b/CICD_Workflows/ci-cd-pipeline.yml
@@ -85,7 +85,7 @@ jobs:
     name: Run Tests
     if: ${{ needs.unpack_inputs.outputs.skipTests != 'true' }}
     needs: unpack_inputs
-    uses: avalin/unity-ci-templates/.github/workflows/step-1-test.yml@v1
+    uses: avalin/unity-ci-cd/.github/workflows/step-1-test.yml@v1
     with:
       runnerMain: ${{ inputs.runnerMain }}
       unityVersion: ${{ needs.unpack_inputs.outputs.unityVersion }}
@@ -111,7 +111,7 @@ jobs:
       always() &&
       needs.unpack_inputs.outputs.testsOnly != 'true' &&
       (needs.run_tests.result == 'success' || needs.run_tests.result == 'skipped')
-    uses: avalin/unity-ci-templates/.github/workflows/step-2-build.yml@v1
+    uses: avalin/unity-ci-cd/.github/workflows/step-2-build.yml@v1
     with:
       # If the event is a push with a tag, force buildType to "release"; otherwise, use the input.
       runnerMain: ${{ inputs.runnerMain }}
@@ -145,7 +145,7 @@ jobs:
         needs.unpack_inputs.outputs.buildType == 'release' || 
         needs.unpack_inputs.outputs.buildType == 'release_candidate'
       )
-    uses: avalin/unity-ci-templates/.github/workflows/step-3-release.yml@v1
+    uses: avalin/unity-ci-cd/.github/workflows/step-3-release.yml@v1
     with:
       runnerMain: ${{ inputs.runnerMain }}
       buildType: ${{ needs.unpack_inputs.outputs.buildType }}
@@ -169,7 +169,7 @@ jobs:
        needs.unpack_inputs.outputs.testsOnly != 'true' &&
        needs.release.result == 'success' &&
        inputs.validDeployTargets != '[]'
-    uses: avalin/unity-ci-templates/.github/workflows/step-4-deploy.yml@v1
+    uses: avalin/unity-ci-cd/.github/workflows/step-4-deploy.yml@v1
     with:
       runnerMain: ${{ inputs.runnerMain }}
       runnerMacos: ${{ inputs.runnerMacos }}
@@ -220,7 +220,7 @@ jobs:
         needs.unpack_inputs.outputs.buildType == 'release' || 
         needs.unpack_inputs.outputs.buildType == 'release_candidate'
       )
-    uses: avalin/unity-ci-templates/.github/workflows/step-5-notify.yml@v1
+    uses: avalin/unity-ci-cd/.github/workflows/step-5-notify.yml@v1
     with:
       runnerMain: ${{ inputs.runnerMain }}
       buildVersion: ${{ needs.unpack_inputs.outputs.buildVersion }}

--- a/CICD_Workflows/ci-cd-redeployer.yml
+++ b/CICD_Workflows/ci-cd-redeployer.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
       - name: Run Project Name Sanitizer
         id: sanitize
-        uses: avalin/unity-ci-templates/.github/actions/resolve-project-name@v1
+        uses: avalin/unity-ci-cd/.github/actions/resolve-project-name@v1
         with:
           projectNameInput: ${{ vars.PROJECT_NAME }}
 
@@ -108,7 +108,7 @@ jobs:
     needs: 
       - sanitize_project_name
       - validate_release
-    uses: avalin/unity-ci-templates/.github/workflows/step-4-deploy.yml@v1
+    uses: avalin/unity-ci-cd/.github/workflows/step-4-deploy.yml@v1
     with:
       buildType: release
       runnerMain: ${{ inputs.runnerMain }}
@@ -128,7 +128,7 @@ jobs:
     name: Notify
     needs: 
       - redeploy
-    uses: avalin/unity-ci-templates/.github/workflows/step-5-notify.yml@v1
+    uses: avalin/unity-ci-cd/.github/workflows/step-5-notify.yml@v1
     with:
       runnerMain: ${{ inputs.runnerMain }}
       buildVersion: ${{ inputs.buildVersion }}


### PR DESCRIPTION
Since there's been an update of the project name, this caused an update also of all the URLs.

Maybe some of them are not necessary (I remember something about GitHub keeping a redirect active from the old name to the new, at least for some time), but at least for me it was strictly necessary on ci-cd-dispatcher.yml.

I've performed the replacements automatically and then given a cursory look: they all seem correct, but I don't know the internals of the project quite well enough to say!