### PR TITLE
fix: add the required runnerMacos parameter

### DIFF
--- a/CICD_Workflows/ci-cd-dispatcher.yml
+++ b/CICD_Workflows/ci-cd-dispatcher.yml
@@ -133,6 +133,7 @@ jobs:
     uses: avalin/unity-ci-templates/.github/workflows/prepare-metadata.yml@main
     with:
       runnerMain: ${{ needs.resolve_runners.outputs.main }}
+      runnerMacos: ${{ needs.resolve_runners.outputs.macos }}
       unityVersion: ${{ vars.UNITY_VERSION }}
       projectName: ${{ vars.PROJECT_NAME }}
       skipTests: ${{ inputs.skipTests }}


### PR DESCRIPTION
prepare-metadata.yml required the runnerMacos parameter, but the ci-cd-dispatcher.yml template is passing only runnerMain.